### PR TITLE
修复 issue-writer-helper 模块的小问题

### DIFF
--- a/dist/oh-my-github.user.js
+++ b/dist/oh-my-github.user.js
@@ -1,6 +1,6 @@
 // ==UserScript==
 // @name            Oh-My-GitHub
-// @version         0.1.0
+// @version         0.1.1
 // @author          cssmagic
 // @namespace       https://github.com/UserScript
 // @homepage        https://github.com/UserScript/Oh-My-GitHub
@@ -1635,7 +1635,8 @@ void function () {
 			var title = ''
 
 			// normal headline in markdown
-			var reHeadline = /^#{1,6}\s*(.+)$/
+			// only search h1, to reduce misjudging
+			var reHeadline = /^#\s*([^#].*)$/
 			var guessMarkdownTitle = reHeadline.exec(firstLine)
 			if (guessMarkdownTitle) {
 				title = guessMarkdownTitle[1]

--- a/src/meta.js
+++ b/src/meta.js
@@ -1,6 +1,6 @@
 // ==UserScript==
 // @name            Oh-My-GitHub
-// @version         0.1.0
+// @version         0.1.1
 // @author          cssmagic
 // @namespace       https://github.com/UserScript
 // @homepage        https://github.com/UserScript/Oh-My-GitHub

--- a/src/module/issue-writer-helper.js
+++ b/src/module/issue-writer-helper.js
@@ -92,7 +92,8 @@ void function () {
 			var title = ''
 
 			// normal headline in markdown
-			var reHeadline = /^#{1,6}\s*(.+)$/
+			// only search h1, to reduce misjudging
+			var reHeadline = /^#\s*([^#].*)$/
 			var guessMarkdownTitle = reHeadline.exec(firstLine)
 			if (guessMarkdownTitle) {
 				title = guessMarkdownTitle[1]


### PR DESCRIPTION
每当在 issue 编辑状态下粘贴内容时，都会检测内容标题与当前 issue 标题的匹配度。原有的标题提取过于宽松，导致在粘贴内容时经常误判并打扰。因此，现在把标题的提取限制在 h1 级别。
